### PR TITLE
Use Lombok ExceptionType JDK 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,7 +143,7 @@ tasks.jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                counter = "LINE"
+                counter = "INSTRUCTION"
                 minimum = "0.9".toBigDecimal()
             }
         }

--- a/src/lombok.config
+++ b/src/lombok.config
@@ -1,3 +1,4 @@
 config.stopBubbling = true
 lombok.accessors.fluent = true
 lombok.addLombokGeneratedAnnotation = true
+lombok.nonNull.exceptionType = JDK


### PR DESCRIPTION
to use Objects.requireNonNull instead if (xxx == null) to increase the code-coverage and have better error messages

https://projectlombok.org/features/NonNull